### PR TITLE
[FD-266] Added optional correlation attribute

### DIFF
--- a/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatistics.java
+++ b/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatistics.java
@@ -3,6 +3,7 @@ package com.asymmetrik.nifi.standard.processors.stats;
 import java.util.Map;
 import java.util.Optional;
 
+import com.asymmetrik.nifi.standard.processors.util.MomentAggregator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -49,9 +50,10 @@ public class CalculateLatencyStatistics extends AbstractStatsProcessor {
 
     private volatile String keyName;
 
+
     @Override
     protected void init(ProcessorInitializationContext context) {
-        properties = ImmutableList.of(ATTR_NAME, REPORTING_INTERVAL, BATCH_SIZE);
+        properties = ImmutableList.of(ATTR_NAME, CORRELATION_ATTR, REPORTING_INTERVAL, BATCH_SIZE);
     }
 
     @OnScheduled

--- a/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatistics.java
+++ b/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatistics.java
@@ -41,6 +41,7 @@ public class CalculateLatencyStatistics extends AbstractStatsProcessor {
      * Property Descriptors
      */
     static final PropertyDescriptor ATTR_NAME = new PropertyDescriptor.Builder()
+            .displayName("Timestamp Attribute")
             .name("timestamp attribute")
             .description("The attribute name holding the timestamp value. This attribute is assumed to be a Java long that represents the milliseconds after epoch.")
             .required(true)

--- a/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatistics.java
+++ b/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatistics.java
@@ -65,43 +65,44 @@ public class CalculateLatencyStatistics extends AbstractStatsProcessor {
     @Override
     protected void updateStats(FlowFile flowFile, MomentAggregator aggregator, long currentTimestamp) {
 
-        // Extract timestamp from original flowfile
-        long eventTime = Long.parseLong(flowFile.getAttribute(keyName));
-
+        String eventTimeAttribute = flowFile.getAttribute(keyName);
         try {
+            // Extract timestamp from original flowfile
+            long eventTime = Long.parseLong(eventTimeAttribute);
+
             // calculate latency and add to aggregator
             Long latency = currentTimestamp - eventTime;
             aggregator.addValue(latency.doubleValue() / 1000.0);
         } catch (NumberFormatException nfe) {
-            getLogger().warn("Unable to convert {} to a long", new Object[]{eventTime}, nfe);
+            getLogger().warn("Unable to convert {} to a long", new Object[]{eventTimeAttribute}, nfe);
         }
     }
 
     @Override
-    protected Optional<Map<String, String>> buildStatAttributes(long currentTimestamp) {
+    protected Optional<Map<String, String>> buildStatAttributes(long currentTimestamp, MomentAggregator aggregator) {
         // emit stats only if there is data
-        // if (aggregator.getN() > 0) {
-        //     int n = aggregator.getN();
-        //     double sum = aggregator.getSum();
-        //     double min = aggregator.getMin();
-        //     double max = aggregator.getMax();
-        //     double mean = aggregator.getMean();
-        //     double stdev = aggregator.getStandardDeviation();
-        //
-        //     Map<String, String> attributes = new ImmutableMap.Builder<String, String>()
-        //             .put("latency_reporter.count", Integer.toString(n))
-        //             .put("latency_reporter.sum", Double.toString(sum))
-        //             .put("latency_reporter.min", Double.toString(min))
-        //             .put("latency_reporter.max", Double.toString(max))
-        //             .put("latency_reporter.avg", Double.toString(mean))
-        //             .put("latency_reporter.stdev", Double.toString(stdev))
-        //             .put("latency_reporter.timestamp", Long.toString(currentTimestamp))
-        //             .put("latency_reporter.units", "Seconds")
-        //             .build();
-        //     return Optional.of(attributes);
-        //
-        // } else {
+        if (aggregator.getN() > 0) {
+            int n = aggregator.getN();
+            double sum = aggregator.getSum();
+            double min = aggregator.getMin();
+            double max = aggregator.getMax();
+            double mean = aggregator.getMean();
+            double stdev = aggregator.getStandardDeviation();
+
+            Map<String, String> attributes = new ImmutableMap.Builder<String, String>()
+                    .put("latency_reporter.count", Integer.toString(n))
+                    .put("latency_reporter.sum", Double.toString(sum))
+                    .put("latency_reporter.min", Double.toString(min))
+                    .put("latency_reporter.max", Double.toString(max))
+                    .put("latency_reporter.avg", Double.toString(mean))
+                    .put("latency_reporter.stdev", Double.toString(stdev))
+                    .put("latency_reporter.timestamp", Long.toString(currentTimestamp))
+                    .put("latency_reporter.units", "Seconds")
+                    .build();
+            return Optional.of(attributes);
+
+        } else {
             return Optional.empty();
-        // }
+        }
     }
 }

--- a/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateVolumeStatistics.java
+++ b/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateVolumeStatistics.java
@@ -7,7 +7,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.asymmetrik.nifi.standard.processors.util.MomentAggregator;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
@@ -79,7 +78,7 @@ public class CalculateVolumeStatistics extends AbstractStatsProcessor {
     }
 
     @Override
-    protected Optional<Map<String, String>> buildStatAttributes(long currentTimestamp) {
+    protected Optional<Map<String, String>> buildStatAttributes(long currentTimestamp, MomentAggregator aggregator) {
         // emit stats only if there is data
         // if (aggregator.getN() > 0) {
         //     Double bucket = (double) bucketIntervalMillis;

--- a/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateVolumeStatistics.java
+++ b/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateVolumeStatistics.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.asymmetrik.nifi.standard.processors.util.MomentAggregator;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
@@ -79,28 +80,29 @@ public class CalculateVolumeStatistics extends AbstractStatsProcessor {
 
     @Override
     protected Optional<Map<String, String>> buildStatAttributes(long currentTimestamp, MomentAggregator aggregator) {
-    // emit stats only if there is data
-    // if (aggregator.getN() > 0) {
-    //     Double bucket = (double) bucketIntervalMillis;
-    //     Double min = 1000.0 * aggregator.getMin() / bucket;
-    //     Double max = 1000.0 * aggregator.getMax() / bucket;
-    //     Double avg = 1000.0 * aggregator.getMean() / bucket;
-    //     Double stdev = 1000.0 * aggregator.getStandardDeviation() / bucket;
-    //
-    //     Map<String, String> attributes = new ImmutableMap.Builder<String, String>()
-    //             .put("volume_statistics.count", Integer.toString(aggregator.getN()))
-    //             .put("volume_statistics.sum", Integer.toString((int) aggregator.getSum()))
-    //             .put("volume_statistics.min", Integer.toString(min.intValue()))
-    //             .put("volume_statistics.max", Integer.toString(max.intValue()))
-    //             .put("volume_statistics.avg", Integer.toString(avg.intValue()))
-    //             .put("volume_statistics.stdev", stdev.toString())
-    //             .put("volume_statistics.timestamp", Long.toString(currentTimestamp))
-    //             .put("volume_statistics.units", "Count/Second")
-    //             .build();
-    //
-    //     return Optional.of(attributes);
-    //
-    // } else {
-        return Optional.empty();
+        // emit stats only if there is data
+        if (aggregator.getN() > 0) {
+            Double bucket = (double) bucketIntervalMillis;
+            Double min = 1000.0 * aggregator.getMin() / bucket;
+            Double max = 1000.0 * aggregator.getMax() / bucket;
+            Double avg = 1000.0 * aggregator.getMean() / bucket;
+            Double stdev = 1000.0 * aggregator.getStandardDeviation() / bucket;
+
+            Map<String, String> attributes = new ImmutableMap.Builder<String, String>()
+                    .put("volume_statistics.count", Integer.toString(aggregator.getN()))
+                    .put("volume_statistics.sum", Integer.toString((int) aggregator.getSum()))
+                    .put("volume_statistics.min", Integer.toString(min.intValue()))
+                    .put("volume_statistics.max", Integer.toString(max.intValue()))
+                    .put("volume_statistics.avg", Integer.toString(avg.intValue()))
+                    .put("volume_statistics.stdev", stdev.toString())
+                    .put("volume_statistics.timestamp", Long.toString(currentTimestamp))
+                    .put("volume_statistics.units", "Count/Second")
+                    .build();
+
+            return Optional.of(attributes);
+
+        } else {
+            return Optional.empty();
+        }
     }
 }

--- a/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateVolumeStatistics.java
+++ b/bundles/standard-bundle/standard-processors/src/main/java/com/asymmetrik/nifi/standard/processors/stats/CalculateVolumeStatistics.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.asymmetrik.nifi.standard.processors.util.MomentAggregator;
 import com.google.common.collect.ImmutableList;
 
 import org.apache.nifi.annotation.behavior.InputRequirement;
@@ -66,7 +67,7 @@ public class CalculateVolumeStatistics extends AbstractStatsProcessor {
     }
 
     @Override
-    protected void updateStats(FlowFile flowFile, long currentTimestamp) {
+    protected void updateStats(FlowFile flowFile, MomentAggregator aggregator, long currentTimestamp) {
         count.incrementAndGet();
 
         // Add the number of flowfiles seen if the window time is exceeded, then reset the counter
@@ -78,29 +79,28 @@ public class CalculateVolumeStatistics extends AbstractStatsProcessor {
 
     @Override
     protected Optional<Map<String, String>> buildStatAttributes(long currentTimestamp, MomentAggregator aggregator) {
-        // emit stats only if there is data
-        if (aggregator.getN() > 0) {
-            Double bucket = (double) bucketIntervalMillis;
-            Double min = 1000.0 * aggregator.getMin() / bucket;
-            Double max = 1000.0 * aggregator.getMax() / bucket;
-            Double avg = 1000.0 * aggregator.getMean() / bucket;
-            Double stdev = 1000.0 * aggregator.getStandardDeviation() / bucket;
-
-            Map<String, String> attributes = new ImmutableMap.Builder<String, String>()
-                    .put("volume_statistics.count", Integer.toString(aggregator.getN()))
-                    .put("volume_statistics.sum", Integer.toString((int) aggregator.getSum()))
-                    .put("volume_statistics.min", Integer.toString(min.intValue()))
-                    .put("volume_statistics.max", Integer.toString(max.intValue()))
-                    .put("volume_statistics.avg", Integer.toString(avg.intValue()))
-                    .put("volume_statistics.stdev", stdev.toString())
-                    .put("volume_statistics.timestamp", Long.toString(currentTimestamp))
-                    .put("volume_statistics.units", "Count/Second")
-                    .build();
-
-            return Optional.of(attributes);
-
-        } else {
-            return Optional.empty();
-        }
+    // emit stats only if there is data
+    // if (aggregator.getN() > 0) {
+    //     Double bucket = (double) bucketIntervalMillis;
+    //     Double min = 1000.0 * aggregator.getMin() / bucket;
+    //     Double max = 1000.0 * aggregator.getMax() / bucket;
+    //     Double avg = 1000.0 * aggregator.getMean() / bucket;
+    //     Double stdev = 1000.0 * aggregator.getStandardDeviation() / bucket;
+    //
+    //     Map<String, String> attributes = new ImmutableMap.Builder<String, String>()
+    //             .put("volume_statistics.count", Integer.toString(aggregator.getN()))
+    //             .put("volume_statistics.sum", Integer.toString((int) aggregator.getSum()))
+    //             .put("volume_statistics.min", Integer.toString(min.intValue()))
+    //             .put("volume_statistics.max", Integer.toString(max.intValue()))
+    //             .put("volume_statistics.avg", Integer.toString(avg.intValue()))
+    //             .put("volume_statistics.stdev", stdev.toString())
+    //             .put("volume_statistics.timestamp", Long.toString(currentTimestamp))
+    //             .put("volume_statistics.units", "Count/Second")
+    //             .build();
+    //
+    //     return Optional.of(attributes);
+    //
+    // } else {
+        return Optional.empty();
     }
 }

--- a/bundles/standard-bundle/standard-processors/src/main/resources/docs/com.asymmetrik.nifi.standard.processors.AttributeTumblingWindow/additionalDetails.html
+++ b/bundles/standard-bundle/standard-processors/src/main/resources/docs/com.asymmetrik.nifi.standard.processors.AttributeTumblingWindow/additionalDetails.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>AutoTerminator</title>
+    <link rel="stylesheet" href="../../css/component-usage.css" type="text/css"/>
+</head>
+
+<body>
+<h2 style="padding-bottom:0;margin-bottom: 0;">Description:</h2>
+<div>
+    Track a Tumbling Window based on evaluating an Expression Language expression on each FlowFile and add that value to the processor's state.
+    Each FlowFile will be emitted with the count of FlowFiles and total aggregate value of values processed in the current time window. It should be
+    noted that the aggregated counts are reset after each Time Window elapses. This behaviour is slightly differently than the built-in NiFi processor
+    named AttributeRollingWindow.
+</div>
+<h2 style="padding-bottom:0;margin-bottom: 0;">Basic Usage:</h2>
+<div>
+    Aggregate an expression language value within a time window, reporting the sum and count at the end of the window. One common use-case is to use
+    this as a counter within a fixed time window. For example, compute and report the average latency. This would be implemented by
+    simply using 1-minute time window to sum the extracted flowfile attribute that represents latency and then sending the metrics to an external service,
+    like CloudWatch or DataDog.
+</div>
+<h2 style="padding-bottom:0;margin-bottom: 3px;">Relationships:</h2>
+<div style="margin-bottom: 10px">
+    <b>elapsed</b><br/>
+    this relationship receives one flowfile when the time window tumbles. For example, if the time window is set to 1 minute, this relationship
+    will receive a flowfile every minute. The contents of this flowfile will remoain unchanged, but the latest metrics attributes will be added to
+    AttributeTumblingWindow.sum and AttributeTumblingWindow.count.
+</div>
+<div style="margin-bottom: 10px">
+    <b>non-elapsed</b><br/>
+    this relationship receives every flowfile except the one when the time window tumbles. As such, if downstream processors require
+    all events, both non-elapsed and elapsed relationships should be used.
+</div>
+<div style="margin-bottom: 10px">
+    <b>failure</b><br/>
+    this relationship receives flowfile that could not be processed. The most common case is when the attribute being aggregated
+    is not parsable to a real number.
+</div>
+</body>
+</html>
+

--- a/bundles/standard-bundle/standard-processors/src/main/resources/docs/com.asymmetrik.nifi.standard.processors.GetWebpage/additionalDetails.html
+++ b/bundles/standard-bundle/standard-processors/src/main/resources/docs/com.asymmetrik.nifi.standard.processors.GetWebpage/additionalDetails.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>AutoTerminator</title>
+
+    <link rel="stylesheet" href="../../css/component-usage.css" type="text/css"/>
+</head>
+
+<body>
+<h2>Description:</h2>
+<p>
+    This processor consumes every flowfile that it receives. It is intended to be used for during debugging.  In production flows, where data loss is
+    unacceptable, this processor should <b>not</b> be used.
+</p>
+<h4>Basic Usage:</h4>
+<p>
+Emits the following metrics to CloudWatch (if configured):
+</p>
+<h4>Relationships:</h4>
+<p>
+<ul>
+    <li>nowhere
+        <ul>this relationship never receives any data, but it exists solely because NiFi does not behave properly when processors contain no relationships.
+        At the time of this writing, template backup and restore did not work properly for processor without at least one relationship.</ul>
+    </li>
+</ul>
+</p>
+</body>
+</html>
+

--- a/bundles/standard-bundle/standard-processors/src/main/resources/docs/com.asymmetrik.nifi.standard.processors.RouteOnBackPressure/additionalDetails.html
+++ b/bundles/standard-bundle/standard-processors/src/main/resources/docs/com.asymmetrik.nifi.standard.processors.RouteOnBackPressure/additionalDetails.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>AutoTerminator</title>
+
+    <link rel="stylesheet" href="../../css/component-usage.css" type="text/css"/>
+</head>
+
+<body>
+<h2 style="padding-bottom:0;margin-bottom: 0;">Description:</h2>
+<div>
+</div>
+
+<h2 style="padding-bottom:0;margin-bottom: 0;">Basic Usage:</h2>
+<div>
+</div>
+
+<h2 style="padding-bottom:0;margin-bottom: 0;">Relationships:</h2>
+<div>
+</div>
+
+</body>
+</html>
+

--- a/bundles/standard-bundle/standard-processors/src/test/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatisticsTest.java
+++ b/bundles/standard-bundle/standard-processors/src/test/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatisticsTest.java
@@ -48,8 +48,8 @@ public class CalculateLatencyStatisticsTest {
         // send 20 files through
         for (int i = 0; i < 20; i++) {
             runner.enqueue(data, attributes);
-            runner.run();
         }
+        runner.run();
 
         // all 20 originals emitted
         runner.assertTransferCount(AbstractStatsProcessor.REL_ORIGINAL, 20);
@@ -123,8 +123,8 @@ public class CalculateLatencyStatisticsTest {
 
         for (int i = 0; i < 20; i++) {
             runner.enqueue(data, attributes);
-            runner.run();
         }
+        runner.run();
 
         // nothing was aggregated, so no stats emitted
         runner.assertTransferCount(AbstractStatsProcessor.REL_STATS, 0);

--- a/bundles/standard-bundle/standard-processors/src/test/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatisticsTest.java
+++ b/bundles/standard-bundle/standard-processors/src/test/java/com/asymmetrik/nifi/standard/processors/stats/CalculateLatencyStatisticsTest.java
@@ -212,13 +212,13 @@ public class CalculateLatencyStatisticsTest {
     }
 
     private void assertStatAttributesPresent(MockFlowFile f) {
-        assertNotNull(Integer.parseInt(f.getAttribute("latency_reporter.count")));
-        assertNotNull(Double.parseDouble(f.getAttribute("latency_reporter.sum")));
-        assertNotNull(Double.parseDouble(f.getAttribute("latency_reporter.min")));
-        assertNotNull(Double.parseDouble(f.getAttribute("latency_reporter.max")));
-        assertNotNull(Double.parseDouble(f.getAttribute("latency_reporter.avg")));
-        assertNotNull(Double.parseDouble(f.getAttribute("latency_reporter.stdev")));
-        assertNotNull(Long.parseLong(f.getAttribute("latency_reporter.timestamp")));
+        assertNotNull(f.getAttribute("latency_reporter.count"));
+        assertNotNull(f.getAttribute("latency_reporter.sum"));
+        assertNotNull(f.getAttribute("latency_reporter.min"));
+        assertNotNull(f.getAttribute("latency_reporter.max"));
+        assertNotNull(f.getAttribute("latency_reporter.avg"));
+        assertNotNull(f.getAttribute("latency_reporter.stdev"));
+        assertNotNull(f.getAttribute("latency_reporter.timestamp"));
         assertEquals("Seconds", f.getAttribute("latency_reporter.units"));
     }
 


### PR DESCRIPTION
Adding a correlation attribute allow this processor to compute stats on a heterogenous stream such that statistics from flowfiles sharing a common attribute value will computed together.